### PR TITLE
Volume Snapshot User Guide Re-write

### DIFF
--- a/snapshot/doc/user-guide.md
+++ b/snapshot/doc/user-guide.md
@@ -1,7 +1,7 @@
 Persistent Volume Snapshots in Kubernetes
 =========================================
 
-This document describes current state of persistent volume snapshot support in Kubernetes provided by external controller and provisioner. Familiarity with [Kubernetes API concepts](https://kubernetes.io/docs/concepts/) is suggested.
+This document describes current state of persistent volume snapshot support in Kubernetes provided by external controller and provisioner. Familiarity with [Kubernetes API concepts](https://kubernetes.io/docs/concepts/) is recommended.
 
 ## Introduction
 


### PR DESCRIPTION
Volume Snapshot User Guide re-write in order to:
- Delete information that are not essential for using Volume Snapshot features.
- Keep the level of details similar to level of details in Persistent Volumes chapter in Kubernetes documentation.
- Add descriptions of a couple of Volume Snapshot features.